### PR TITLE
Pin `fastapi` version to 0.103

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,2 @@
-fastapi[all]
+fastapi ~= 0.103
+uvicorn[standard]


### PR DESCRIPTION
For now, pin the version of `fastapi` to 0.103 in `requirements.txt` as `fastapi@0.104` requires Python >=3.8.